### PR TITLE
AudioFX: read current output device from AudioService

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -38,6 +38,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_ROUTING" />
 
     <application
             android:icon="@mipmap/ic_launcher_audiofx"


### PR DESCRIPTION
This uses AudioManager's OnAudioPortUpdateListener callback to provide a
more accurate current device state.

Change-Id: Ia28927b9c9aff43111c7d8b10cfac888583e096e
Signed-off-by: Roman Birg roman@cyngn.com
